### PR TITLE
ldd replaced with objdump -p for dependency listing

### DIFF
--- a/statan.py
+++ b/statan.py
@@ -114,7 +114,7 @@ class Static:
 
     def dependencies(self):
         try:
-            output = subprocess.check_output(["ldd", self.file])
+            output = subprocess.check_output(["objdump", "-p", self.file, "| grep NEEDED"])
             return output
         except:
             pass


### PR DESCRIPTION
The ldd attempts to display a list of dynamic linkages by executing the target binary with an "magic environment" setting.  For a normal binary that's been compiled and linked with glibc and the normal GNU linker this will be adequate.

However, crafted sources linked against an alternative library and linker can execute arbitrary code in lieu (or in addition to) this. Ref: http://www.catonmat.net/blog/ldd-arbitrary-code-execution/

Using objdump eliminates this.
